### PR TITLE
Fix DaVinci Resolve scripting on Windows: FUSION_PYTHON3_HOME + Python 3.10 setup

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,20 @@
+name: Tests
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  unit-tests:
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+        python-version: ["3.10", "3.11"]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Run unit tests
+        run: python -m unittest discover -s tests -v

--- a/.gitignore
+++ b/.gitignore
@@ -15,8 +15,10 @@ env/
 ENV/
 .env/
 .venv/
+.venv310/
 env.bak/
 venv.bak/
+.python-version
 
 # UV specific
 .uv/

--- a/README.md
+++ b/README.md
@@ -86,6 +86,17 @@ The DLL preload is Windows-specific and is skipped automatically. Ensure a pytho
 Python 3.10/3.11, install the same dependencies, and run `python server.py`. The scripting
 modules are found automatically; you can override the location with `RESOLVE_SCRIPT_PATH`.
 
+For example, create a regular virtual environment on macOS with:
+
+```bash
+/usr/local/bin/python3.11 -m venv .venv
+./.venv/bin/python -m pip install --upgrade pip
+./.venv/bin/python -m pip install "mcp[cli]>=1.4.1" "pydantic>=2.10.6"
+./.venv/bin/python server.py
+```
+
+On Apple Silicon, adjust the Python path if your python.org installation is elsewhere.
+
 ## Claude Desktop Integration
 
 Point Claude Desktop at the launcher via `claude_desktop_config.json`
@@ -108,6 +119,23 @@ Point Claude Desktop at the launcher via `claude_desktop_config.json`
 
 Replace the path with the absolute path to this project. Restart Claude Desktop and look
 for the tools/hammer icon to confirm the server loaded.
+
+On macOS, use the virtual environment's Python directly instead of the PowerShell
+launcher. The configuration file is
+`~/Library/Application Support/Claude/claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "davinci-resolve": {
+      "command": "/absolute/path/to/davinci-resolve-mcp/.venv/bin/python",
+      "args": [
+        "/absolute/path/to/davinci-resolve-mcp/server.py"
+      ]
+    }
+  }
+}
+```
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,3 @@
-Here’s an updated version of the README with enhancements reflecting the expanded functionality of the `ResolveAPI` class, improved clarity, and additional details for setup and usage. The structure remains consistent with your original README, but I’ve incorporated the new features (e.g., gallery management, track control, audio adjustments, playback, etc.) and refined the instructions for `uv` installation and Claude integration.
-
----
-
 # DaVinci Resolve MCP Server
 
 A Model Context Protocol (MCP) server that enables AI assistants like Claude to interact with DaVinci Resolve Studio, providing advanced control over editing, color grading, audio, and more.
@@ -22,187 +18,128 @@ This server implements the MCP protocol to create a bridge between AI assistants
 
 ## Requirements
 
-- DaVinci Resolve Studio 18.0 or newer
-- Python 3.10 or newer
-- Access to the DaVinci Resolve scripting API
+- **DaVinci Resolve _Studio_ 18.0 or newer.** External scripting (which this server
+  relies on) is a Studio-only feature. The **free** edition does not expose the
+  external scripting API — the server will start but report that it cannot connect.
+- **A regular python.org Python 3.10 or 3.11 (64-bit).** Resolve's scripting module
+  does `import imp`, which was removed in Python 3.12, so **3.12+ will not work**.
+  Do **not** use `uv`-managed Python: its standalone builds crash when loading
+  Resolve's native `fusionscript.dll`. See [Setup](#setup-windows) below.
+- Access to the DaVinci Resolve scripting API (installed with Resolve).
 
-## Installation with uv
+## Setup (Windows)
 
-[uv](https://github.com/astral-sh/uv) is a fast, modern Python package installer and resolver that outperforms pip. Follow these steps to install and set up the DaVinci Resolve MCP server using `uv`:
+> **Why not `uv`?** Two reasons: `uv` defaults to Python 3.13 (fails on `import imp`),
+> and even when pinned to 3.10/3.11 its *standalone* Python build crashes when Resolve's
+> native `fusionscript.dll` is loaded. Use a normal python.org install with a plain venv.
 
-### 1. Install uv
+### 1. Install a compatible Python
 
-If `uv` is not installed:
+Install **python.org Python 3.10 (64-bit)** — for example with winget:
 
-```bash
-# Using pip (ensure pip is for Python 3.10+)
-pip install uv
-
-# Using Homebrew (macOS)
-brew install uv
-
-# Using Conda
-conda install -c conda-forge uv
+```powershell
+winget install --id Python.Python.3.10 -e
 ```
 
-Verify installation:
+### 2. Create the virtual environment and install dependencies
 
-```bash
-uv --version
+From the project directory, create the venv with that interpreter (this repo uses
+`.venv310`) and install the dependencies:
+
+```powershell
+& "$env:LOCALAPPDATA\Programs\Python\Python310\python.exe" -m venv .venv310
+.\.venv310\Scripts\python.exe -m pip install --upgrade pip
+.\.venv310\Scripts\python.exe -m pip install "mcp[cli]>=1.4.1" "pydantic>=2.10.6"
 ```
 
-### 2. Create a Virtual Environment
+### 3. Run the server
 
-Create and activate a virtual environment to isolate dependencies:
+Use the provided launcher, which sets up a clean environment for you:
 
-```bash
-uv venv
-source .venv/bin/activate  # On Windows: .venv\Scripts\activate
+```powershell
+.\run_server.ps1
 ```
 
-### 3. Install the DaVinci Resolve MCP Server
+`run_server.ps1` builds a minimal `PATH` (exposing only this project's Python 3.10 plus
+the Windows system directories) and sets the `RESOLVE_SCRIPT_API` / `RESOLVE_SCRIPT_LIB`
+variables. `resolve_env.py` additionally preloads the matching `python3.dll` from inside
+the process. Both are needed to avoid the DLL conflict described in
+[Troubleshooting](#troubleshooting).
 
-Install the server and its dependencies from the project directory:
-
-```bash
-# From the project directory (editable install for development)
-uv install -e .
-
-# Or directly from GitHub (replace with your repo URL)
-uv install git+https://github.com/yourusername/davinci-resolve-mcp.git
-```
-
-### 4. Install Dependencies
-
-Ensure `requirements.txt` includes:
+On DaVinci Resolve **Studio** (running), you should see:
 
 ```
-mcp
-pydantic
+... - ResolveAPI - INFO - Connected to Resolve using ...
+... - resolve_mcp - INFO - Successfully connected to DaVinci Resolve.
 ```
 
-Install them:
-
-```bash
-uv install -r requirements.txt
-```
-
-## Configuration
-
-Before running the server, ensure:
-
-1. DaVinci Resolve Studio is running.
-2. Python can access the DaVinci Resolve scripting API (handled automatically by `ResolveAPI` in most cases).
-
-### API Access Configuration
-
-The `ResolveAPI` class dynamically locates the scripting API, but you may need to configure it manually in some cases:
-
-#### macOS
-
-The API is typically available at:
-
-- `/Library/Application Support/Blackmagic Design/DaVinci Resolve/Developer/Scripting/Modules`
-- Or user-specific: `~/Library/Application Support/Blackmagic Design/DaVinci Resolve/Developer/Scripting/Modules`
-
-No additional setup is usually required.
-
-#### Windows
-
-Add the API path if not detected:
-
-```python
-import sys
-sys.path.append("C:\\ProgramData\\Blackmagic Design\\DaVinci Resolve\\Support\\Developer\\Scripting\\Modules")
-```
-
-#### Linux
-
-Set the environment variable:
-
-```bash
-export PYTHONPATH=$PYTHONPATH:/opt/resolve/Developer/Scripting/Modules
-```
-
-Alternatively, set a custom path via an environment variable:
-
-```bash
-export RESOLVE_SCRIPT_PATH="/custom/path/to/scripting/modules"
-```
-
-## Running the Server
-
-Start the MCP server:
-
-```bash
-# Run directly with Python
-python -m resolve_mcp.server
-
-# Or with uv
-uv run resolve_mcp/server.py
-```
-
-The server will launch and connect to DaVinci Resolve, logging output like:
+On the **free** edition it starts but logs (without crashing):
 
 ```
-2025-03-19 ... - resolve_mcp - INFO - Successfully connected to DaVinci Resolve.
+... - ResolveAPI - ERROR - DaVinci Resolve scripting could not be initialized.
+    External scripting requires DaVinci Resolve Studio; the free edition does not support it.
 ```
 
-### Claude Integration Configuration
+### macOS / Linux
 
-To integrate with Claude Desktop, update your `claude_desktop_config.json` (e.g., `~/Library/Application Support/Claude/claude_desktop_config.json` on macOS):
+The DLL preload is Windows-specific and is skipped automatically. Ensure a python.org
+Python 3.10/3.11, install the same dependencies, and run `python server.py`. The scripting
+modules are found automatically; you can override the location with `RESOLVE_SCRIPT_PATH`.
+
+## Claude Desktop Integration
+
+Point Claude Desktop at the launcher via `claude_desktop_config.json`
+(`%APPDATA%\Claude\claude_desktop_config.json` on Windows):
 
 ```json
 {
   "mcpServers": {
     "davinci-resolve": {
-      "command": "/path/to/uv",
+      "command": "powershell",
       "args": [
-        "run",
-        "--directory",
-        "/path/to/davinci-resolve-mcp",
-        "resolve_mcp/server.py"
+        "-NoProfile",
+        "-ExecutionPolicy", "Bypass",
+        "-File", "C:\\path\\to\\davinci-resolve-mcp\\run_server.ps1"
       ]
     }
   }
 }
 ```
 
-- Replace `/path/to/uv` with the path to your `uv` executable (e.g., `/usr/local/bin/uv` or `C:\Users\username\.cargo\bin\uv.exe`).
-- Replace `/path/to/davinci-resolve-mcp` with the absolute path to your project directory.
-
-Restart Claude Desktop to enable the server. Look for a hammer icon in the input box to confirm integration.
+Replace the path with the absolute path to this project. Restart Claude Desktop and look
+for the tools/hammer icon to confirm the server loaded.
 
 ## Troubleshooting
 
-### Connection Issues
+### "Failed to connect" / "requires DaVinci Resolve Studio"
 
-If the server fails to connect:
+External scripting is a **Studio-only** feature. On the free edition the scripting library
+cannot be initialized from an external process, and the server will run in a disconnected
+state. There is no software workaround — Studio is required.
 
-1. Ensure DaVinci Resolve Studio is running.
-2. Check Resolve’s preferences to confirm scripting is enabled.
-3. Verify Python version compatibility (3.10+ recommended):
-   ```bash
-   python --version
-   ```
-4. Confirm API paths are accessible (see logs in `~/Library/Logs/Claude/mcp*.log` on macOS or `%userprofile%\AppData\Roaming\Claude\Logs\` on Windows).
+### The process crashes on startup (access violation) when run *without* the launcher
+
+Resolve's `fusionscript.dll` binds to the first `python3.dll` it finds. If another Python
+is on your `PATH` — commonly **Anaconda** (`python312.dll`) or a **python.org 3.13** — that
+foreign runtime gets loaded into the 3.10 interpreter and the process dies with an access
+violation (`0xC0000005`).
+
+Always launch via `run_server.ps1`, which isolates `PATH`. If you invoke `server.py`
+directly, make sure Anaconda / other Python installs are not ahead of your 3.10 on `PATH`.
+`resolve_env.py` mitigates this by preloading the correct `python3.dll` and by probing the
+scripting import in a subprocess so a crash there cannot take down the server.
+
+### `import imp` / `ModuleNotFoundError` at startup
+
+You are on Python 3.12 or newer (the `imp` module was removed). Recreate the venv with
+Python 3.10 or 3.11 as shown in [Setup](#setup-windows).
 
 ### Dependency Issues
 
-If modules like `mcp` or `pydantic` are missing:
+If `mcp` or `pydantic` are missing, install them into the venv:
 
-```bash
-uv install mcp pydantic
-```
-
-### Python Version Compatibility
-
-Switch to a compatible version with `pyenv` if needed:
-
-```bash
-pyenv install 3.10.12
-pyenv shell 3.10.12
-uv install -r requirements.txt
+```powershell
+.\.venv310\Scripts\python.exe -m pip install "mcp[cli]>=1.4.1" "pydantic>=2.10.6"
 ```
 
 ## Available Tools and Resources
@@ -275,21 +212,10 @@ To contribute:
 
 1. Fork the repository: `https://github.com/yourusername/davinci-resolve-mcp`
 2. Create a feature branch: `git checkout -b feature-name`
-3. Install dependencies: `uv install -e .`
-4. Make changes and test: `uv run resolve_mcp/server.py`
+3. Set up the venv and dependencies (see [Setup](#setup-windows)).
+4. Make changes and test: `.\run_server.ps1`
 5. Submit a pull request.
 
 ## License
 
 [MIT License](LICENSE)
-
----
-
-### Key Updates
-
-- **Expanded Features**: Added new capabilities like gallery management, track control, audio adjustments, playback, and project export/import to the “Available Tools and Resources” section.
-- **Installation Clarity**: Improved `uv` instructions with verification steps and explicit paths for Claude integration.
-- **Troubleshooting**: Enhanced with specific commands and log locations for debugging.
-- **Configuration**: Updated API access notes to reflect the dynamic path handling in `ResolveAPI`.
-
-This README now fully aligns with the enhanced `ResolveAPI` class, providing a comprehensive guide for users and developers. Let me know if you’d like further adjustments!

--- a/README.md
+++ b/README.md
@@ -117,17 +117,28 @@ External scripting is a **Studio-only** feature. On the free edition the scripti
 cannot be initialized from an external process, and the server will run in a disconnected
 state. There is no software workaround — Studio is required.
 
-### The process crashes on startup (access violation) when run *without* the launcher
+### The process crashes on startup (access violation `0xC0000005`)
 
-Resolve's `fusionscript.dll` binds to the first `python3.dll` it finds. If another Python
-is on your `PATH` — commonly **Anaconda** (`python312.dll`) or a **python.org 3.13** — that
-foreign runtime gets loaded into the 3.10 interpreter and the process dies with an access
-violation (`0xC0000005`).
+Resolve's `fusionscript.dll` loads a Python 3 runtime when the scripting module is
+imported. It chooses which one from the `FUSION_PYTHON3_HOME` environment variable and,
+**if that is unset, from the Windows registry** (`HKCU`/`HKLM\SOFTWARE\Python\PythonCore`).
+On a machine with several Pythons registered — commonly **Anaconda** (`python312.dll`) or a
+**python.org 3.13** — that fallback picks a *foreign* runtime, loads it into the 3.10
+interpreter, and the process dies with an access violation.
 
-Always launch via `run_server.ps1`, which isolates `PATH`. If you invoke `server.py`
-directly, make sure Anaconda / other Python installs are not ahead of your 3.10 on `PATH`.
-`resolve_env.py` mitigates this by preloading the correct `python3.dll` and by probing the
-scripting import in a subprocess so a crash there cannot take down the server.
+The fix is to set `FUSION_PYTHON3_HOME` to this project's Python 3.10. Both `run_server.ps1`
+and `resolve_env.py` do this for you (and additionally preload the correct `python3.dll` and
+probe the scripting import in a subprocess so a crash there cannot take down the server), so
+**always launch via `run_server.ps1`**. Note that `PATH` isolation alone is *not* enough —
+the registry fallback bypasses `PATH` — which is why `FUSION_PYTHON3_HOME` is required.
+
+### It loads but says `scriptapp('Resolve') returned None`
+
+The scripting module imported successfully but no live Resolve object was returned. Either
+Resolve isn't running, or external scripting is disabled. In Resolve, open
+**Preferences → System → General** and set **"External scripting using"** to **Local**, then
+restart Resolve. Remember that external scripting also **requires DaVinci Resolve Studio** —
+on the free edition this will remain `None`.
 
 ### `import imp` / `ModuleNotFoundError` at startup
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "davinci-resolve-mcp"
 version = "0.1.0"
 description = "Add your description here"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.12"
 dependencies = [
     "mcp[cli]>=1.4.1",
     "pydantic>=2.10.6",

--- a/resolve_api.py
+++ b/resolve_api.py
@@ -41,6 +41,8 @@ class ResolveAPI:
         """
         custom_path = os.environ.get("RESOLVE_SCRIPT_PATH")  # Check for user-defined path
         if custom_path and os.path.exists(custom_path):
+            if custom_path not in sys.path:
+                sys.path.append(custom_path)
             return custom_path
         # Default paths for Resolve scripting module by OS
         base_paths = {
@@ -72,7 +74,7 @@ class ResolveAPI:
         # notably the free edition, which restricts external scripting to Studio.
         # Probe it in a subprocess first so we degrade gracefully instead of dying.
         import resolve_env
-        if not resolve_env.scripting_safe_to_import():
+        if not resolve_env.scripting_safe_to_import(script_path):
             logger.error(
                 "DaVinci Resolve scripting could not be initialized. External "
                 "scripting requires DaVinci Resolve Studio; the free edition does "

--- a/resolve_api.py
+++ b/resolve_api.py
@@ -52,9 +52,10 @@ class ResolveAPI:
         system = platform.system()  # Get current OS
         paths = base_paths.get(system, []) if system != "Darwin" else base_paths["Darwin"]
         for path in ([paths] if isinstance(paths, str) else paths):  # Handle single path or list
-            if os.path.exists(path) and path not in sys.path:
-                sys.path.append(path)  # Add to Python path if not already present
-                return path
+            if os.path.exists(path):
+                if path not in sys.path:
+                    sys.path.append(path)  # Add to Python path if not already present
+                return path  # Return whether or not it was already on sys.path
         return None  # Return None if no valid path is found
 
     def _connect_to_resolve(self) -> None:
@@ -82,7 +83,19 @@ class ResolveAPI:
         try:
             import DaVinciResolveScript as dvr_script  # Import the Resolve scripting API
             self.resolve = dvr_script.scriptapp("Resolve")  # Connect to Resolve app
-            logger.info(f"Connected to Resolve using {script_path}")
+            if self.resolve:
+                logger.info(f"Connected to Resolve using {script_path}")
+            else:
+                # Module loaded, but no live app object. Resolve isn't running, or
+                # external scripting is disabled/unavailable (Preferences > System >
+                # General > "External scripting using" must be Local; external
+                # scripting also requires DaVinci Resolve Studio).
+                logger.error(
+                    "Loaded the Resolve scripting module but scriptapp('Resolve') "
+                    "returned None -- Resolve is not running, or external scripting "
+                    "is disabled (set Preferences > System > General > 'External "
+                    "scripting using' to Local; requires DaVinci Resolve Studio)."
+                )
         except ImportError:
             logger.error(f"Failed to import DaVinciResolveScript from {script_path}")
             self.resolve = None

--- a/resolve_api.py
+++ b/resolve_api.py
@@ -66,6 +66,19 @@ class ResolveAPI:
         if not script_path:
             logger.error("No valid Resolve scripting module path found")
             return
+        # Loading Resolve's fusionscript library can hard-crash the interpreter
+        # (uncatchable access violation) when external scripting is unavailable --
+        # notably the free edition, which restricts external scripting to Studio.
+        # Probe it in a subprocess first so we degrade gracefully instead of dying.
+        import resolve_env
+        if not resolve_env.scripting_safe_to_import():
+            logger.error(
+                "DaVinci Resolve scripting could not be initialized. External "
+                "scripting requires DaVinci Resolve Studio; the free edition does "
+                "not support it. Continuing without a Resolve connection."
+            )
+            self.resolve = None
+            return
         try:
             import DaVinciResolveScript as dvr_script  # Import the Resolve scripting API
             self.resolve = dvr_script.scriptapp("Resolve")  # Connect to Resolve app

--- a/resolve_env.py
+++ b/resolve_env.py
@@ -3,17 +3,20 @@ Environment bootstrap for connecting to DaVinci Resolve's scripting API.
 
 Why this module exists
 ----------------------
-Resolve's ``fusionscript`` native library exports its Python entry points against
-the version-agnostic ``python3.dll`` forwarder (Windows). If *another* Python's
-``python3.dll`` is found on the DLL search path first -- e.g. an Anaconda 3.12 or
-a python.org 3.13 install -- that foreign runtime gets loaded into this
-interpreter and the process dies with an access violation (0xC0000005) the moment
+Resolve's ``fusionscript`` native library loads a Python 3 runtime at import time
+to expose its scripting API. To decide *which* Python, it reads the environment
+variable ``FUSION_PYTHON3_HOME`` and, only if that is unset, falls back to the
+Windows registry (``HKCU``/``HKLM\SOFTWARE\Python\PythonCore``). On a machine with
+several Pythons registered (e.g. an Anaconda 3.12), that fallback can pick a
+*foreign* runtime and load its ``python3xx.dll`` into this 3.10 process, which
+hard-crashes with an access violation (0xC0000005) the moment
 ``DaVinciResolveScript`` imports the library.
 
-Preloading *this* interpreter's own ``python3.dll`` makes ``fusionscript`` bind to
-the correct runtime. We also register the scripting module + library locations via
-the ``RESOLVE_SCRIPT_*`` variables that Blackmagic's ``DaVinciResolveScript.py``
-looks for.
+The fix is to set ``FUSION_PYTHON3_HOME`` to *this* interpreter's home so
+``fusionscript`` binds to our own runtime. We additionally preload our
+``python3.dll`` as belt-and-braces, and register the scripting module + library
+locations via the ``RESOLVE_SCRIPT_*`` variables that Blackmagic's
+``DaVinciResolveScript.py`` looks for.
 
 Importing this module runs the bootstrap automatically. Import it *before*
 anything that pulls in ``DaVinciResolveScript`` / ``resolve_api``.
@@ -67,6 +70,15 @@ def _set_env_defaults() -> None:
     modules = os.path.join(api, "Modules")
     os.environ.setdefault("RESOLVE_SCRIPT_API", api)
     os.environ.setdefault("RESOLVE_SCRIPT_LIB", _script_lib())
+    # Tell Resolve's fusionscript which Python 3 runtime to bind to. Without this
+    # it falls back to the Windows registry (HKCU/HKLM\SOFTWARE\Python\PythonCore)
+    # and can pick a *foreign* interpreter -- e.g. an Anaconda 3.12 -- loading that
+    # runtime's python3xx.dll into this 3.10 process and hard-crashing it with an
+    # access violation (0xC0000005). Pin it to THIS interpreter's home so it binds
+    # to our own python3.dll/python310.dll instead. sys.base_prefix is the real
+    # install dir (venvs point here) that holds the python3xx.dll.
+    if sys.platform == "win32":
+        os.environ["FUSION_PYTHON3_HOME"] = sys.base_prefix
     # Propagate the Modules dir to child processes via PYTHONPATH (used by the
     # safety probe below). We deliberately do NOT touch this process's sys.path --
     # resolve_api._find_scripting_module() adds it itself and only returns a path

--- a/resolve_env.py
+++ b/resolve_env.py
@@ -6,7 +6,7 @@ Why this module exists
 Resolve's ``fusionscript`` native library loads a Python 3 runtime at import time
 to expose its scripting API. To decide *which* Python, it reads the environment
 variable ``FUSION_PYTHON3_HOME`` and, only if that is unset, falls back to the
-Windows registry (``HKCU``/``HKLM\SOFTWARE\Python\PythonCore``). On a machine with
+Windows registry (``HKCU``/``HKLM\\SOFTWARE\\Python\\PythonCore``). On a machine with
 several Pythons registered (e.g. an Anaconda 3.12), that fallback can pick a
 *foreign* runtime and load its ``python3xx.dll`` into this 3.10 process, which
 hard-crashes with an access violation (0xC0000005) the moment
@@ -25,6 +25,7 @@ anything that pulls in ``DaVinciResolveScript`` / ``resolve_api``.
 import os
 import subprocess
 import sys
+from typing import Optional
 
 # Cache for the one-time "is it safe to import the scripting module?" probe.
 _safe_to_import = None
@@ -113,7 +114,7 @@ def _preload_matching_python_dll() -> None:
                 pass
 
 
-def scripting_safe_to_import() -> bool:
+def scripting_safe_to_import(module_path: Optional[str] = None) -> bool:
     """
     Return True if importing ``DaVinciResolveScript`` in *this* process is safe.
 
@@ -122,6 +123,11 @@ def scripting_safe_to_import() -> bool:
     the free edition of DaVinci Resolve, which gates external scripting to Studio.
     We can't catch a native crash, so we reproduce the import in a throwaway
     subprocess and treat a crash there as "not safe".
+
+    ``module_path`` is the directory selected by ``ResolveAPI``. Passing it to the
+    child is required for macOS user-local installations and
+    ``RESOLVE_SCRIPT_PATH`` overrides, which may not be present in the inherited
+    ``PYTHONPATH``.
 
     Exit-code contract of the probe:
         0  -> imported and scriptapp() returned a live object (connected)
@@ -138,10 +144,11 @@ def scripting_safe_to_import() -> bool:
         "sys.exit(0 if d.scriptapp('Resolve') else 10)\n"
     )
     env = os.environ.copy()
-    # Ensure the child can import this module (resolve_env) and the Modules dir.
+    # Ensure the child can import this module and the exact Modules dir selected
+    # by ResolveAPI. The latter may be a macOS user-local or custom path.
     here = os.path.dirname(os.path.abspath(__file__))
     env["PYTHONPATH"] = os.pathsep.join(
-        p for p in (here, env.get("PYTHONPATH", "")) if p
+        p for p in (here, module_path, env.get("PYTHONPATH", "")) if p
     )
     try:
         result = subprocess.run(

--- a/resolve_env.py
+++ b/resolve_env.py
@@ -1,0 +1,150 @@
+"""
+Environment bootstrap for connecting to DaVinci Resolve's scripting API.
+
+Why this module exists
+----------------------
+Resolve's ``fusionscript`` native library exports its Python entry points against
+the version-agnostic ``python3.dll`` forwarder (Windows). If *another* Python's
+``python3.dll`` is found on the DLL search path first -- e.g. an Anaconda 3.12 or
+a python.org 3.13 install -- that foreign runtime gets loaded into this
+interpreter and the process dies with an access violation (0xC0000005) the moment
+``DaVinciResolveScript`` imports the library.
+
+Preloading *this* interpreter's own ``python3.dll`` makes ``fusionscript`` bind to
+the correct runtime. We also register the scripting module + library locations via
+the ``RESOLVE_SCRIPT_*`` variables that Blackmagic's ``DaVinciResolveScript.py``
+looks for.
+
+Importing this module runs the bootstrap automatically. Import it *before*
+anything that pulls in ``DaVinciResolveScript`` / ``resolve_api``.
+"""
+
+import os
+import subprocess
+import sys
+
+# Cache for the one-time "is it safe to import the scripting module?" probe.
+_safe_to_import = None
+
+
+def _resolve_program_dir() -> str:
+    """Directory of the Resolve application (holds fusionscript.dll on Windows)."""
+    if sys.platform == "win32":
+        return os.path.join(
+            os.environ.get("PROGRAMFILES", r"C:\Program Files"),
+            "Blackmagic Design", "DaVinci Resolve",
+        )
+    if sys.platform == "darwin":
+        return "/Applications/DaVinci Resolve/DaVinci Resolve.app/Contents/Libraries/Fusion"
+    return "/opt/resolve/libs/Fusion"
+
+
+def _scripting_dir() -> str:
+    """Root of the Developer/Scripting package that ships the import modules."""
+    if sys.platform == "win32":
+        return os.path.join(
+            os.environ.get("PROGRAMDATA", r"C:\ProgramData"),
+            "Blackmagic Design", "DaVinci Resolve",
+            "Support", "Developer", "Scripting",
+        )
+    if sys.platform == "darwin":
+        return "/Library/Application Support/Blackmagic Design/DaVinci Resolve/Developer/Scripting"
+    return "/opt/resolve/Developer/Scripting"
+
+
+def _script_lib() -> str:
+    """Absolute path to the fusionscript native library for this platform."""
+    if sys.platform == "win32":
+        return os.path.join(_resolve_program_dir(), "fusionscript.dll")
+    if sys.platform == "darwin":
+        return os.path.join(_resolve_program_dir(), "fusionscript.so")
+    return os.path.join(_resolve_program_dir(), "fusionscript.so")
+
+
+def _set_env_defaults() -> None:
+    """Point DaVinciResolveScript.py at the API/library and add Modules to sys.path."""
+    api = _scripting_dir()
+    modules = os.path.join(api, "Modules")
+    os.environ.setdefault("RESOLVE_SCRIPT_API", api)
+    os.environ.setdefault("RESOLVE_SCRIPT_LIB", _script_lib())
+    # Propagate the Modules dir to child processes via PYTHONPATH (used by the
+    # safety probe below). We deliberately do NOT touch this process's sys.path --
+    # resolve_api._find_scripting_module() adds it itself and only returns a path
+    # when it is not already present, so pre-inserting it would break detection.
+    existing = os.environ.get("PYTHONPATH", "")
+    if modules not in existing.split(os.pathsep):
+        os.environ["PYTHONPATH"] = os.pathsep.join(p for p in (modules, existing) if p)
+
+
+def _preload_matching_python_dll() -> None:
+    """
+    Force Resolve's fusionscript to bind to THIS interpreter's runtime by loading
+    our own ``python3.dll`` first. No-op off Windows, where the .so is resolved by
+    absolute path and there is no forwarder ambiguity.
+    """
+    if sys.platform != "win32":
+        return
+    import ctypes
+
+    py3 = os.path.join(sys.base_prefix, "python3.dll")
+    if os.path.exists(py3):
+        try:
+            ctypes.WinDLL(py3)
+        except OSError:
+            pass
+    # Prefer our interpreter dir and the Resolve program dir for DLL resolution.
+    for d in (sys.base_prefix, _resolve_program_dir()):
+        if d and os.path.isdir(d):
+            try:
+                os.add_dll_directory(d)
+            except OSError:
+                pass
+
+
+def scripting_safe_to_import() -> bool:
+    """
+    Return True if importing ``DaVinciResolveScript`` in *this* process is safe.
+
+    Loading fusionscript can hard-crash the interpreter (uncatchable access
+    violation) on setups where external scripting is unavailable -- most notably
+    the free edition of DaVinci Resolve, which gates external scripting to Studio.
+    We can't catch a native crash, so we reproduce the import in a throwaway
+    subprocess and treat a crash there as "not safe".
+
+    Exit-code contract of the probe:
+        0  -> imported and scriptapp() returned a live object (connected)
+        10 -> imported cleanly but scriptapp() returned None (Studio, app closed)
+        anything else / no exit -> the import crashed; do not attempt in-process
+    """
+    global _safe_to_import
+    if _safe_to_import is not None:
+        return _safe_to_import
+
+    probe = (
+        "import resolve_env, sys\n"
+        "import DaVinciResolveScript as d\n"
+        "sys.exit(0 if d.scriptapp('Resolve') else 10)\n"
+    )
+    env = os.environ.copy()
+    # Ensure the child can import this module (resolve_env) and the Modules dir.
+    here = os.path.dirname(os.path.abspath(__file__))
+    env["PYTHONPATH"] = os.pathsep.join(
+        p for p in (here, env.get("PYTHONPATH", "")) if p
+    )
+    try:
+        result = subprocess.run(
+            [sys.executable, "-c", probe],
+            cwd=here,
+            env=env,
+            capture_output=True,
+            timeout=60,
+        )
+        _safe_to_import = result.returncode in (0, 10)
+    except (subprocess.TimeoutExpired, OSError):
+        _safe_to_import = False
+    return _safe_to_import
+
+
+# Run the bootstrap on import.
+_preload_matching_python_dll()
+_set_env_defaults()

--- a/run_server.ps1
+++ b/run_server.ps1
@@ -1,12 +1,14 @@
 <#
     Launches the DaVinci Resolve MCP server with a clean, isolated environment.
 
-    Why a launcher: Resolve's fusionscript library binds to whatever `python3.dll`
-    it finds first. Other Pythons on PATH (Anaconda 3.12, python.org 3.13, ...)
-    will be loaded into this 3.10 interpreter and crash it. We therefore build a
-    minimal PATH that exposes ONLY this project's Python 3.10 plus the Windows
-    system directories. `resolve_env.py` additionally preloads the correct
-    python3.dll from inside the process as a second line of defense.
+    Why a launcher: Resolve's fusionscript library loads a Python 3 runtime when
+    the scripting module is imported. It picks that runtime from
+    FUSION_PYTHON3_HOME (set below) and, if unset, from the Windows registry --
+    where another install (Anaconda 3.12, python.org 3.13, ...) can win and get
+    loaded into this 3.10 interpreter, crashing it. We pin FUSION_PYTHON3_HOME to
+    this project's Python 3.10, build a minimal PATH that exposes only it plus the
+    Windows system dirs, and `resolve_env.py` also sets the var + preloads the
+    correct python3.dll from inside the process as defense in depth.
 
     NOTE: Connecting to Resolve requires DaVinci Resolve *Studio*. The free edition
     does not expose external scripting and the server will report that it could not
@@ -40,5 +42,10 @@ $scripting = Join-Path $env:PROGRAMDATA "Blackmagic Design\DaVinci Resolve\Suppo
 $env:RESOLVE_SCRIPT_API = $scripting
 $env:RESOLVE_SCRIPT_LIB = Join-Path $env:PROGRAMFILES "Blackmagic Design\DaVinci Resolve\fusionscript.dll"
 $env:PYTHONPATH = Join-Path $scripting "Modules"
+
+# Pin the Python that Resolve's fusionscript binds to. Without this it consults
+# the registry and may load a foreign interpreter (e.g. Anaconda's python312.dll)
+# into this 3.10 process, crashing it with an access violation. See resolve_env.py.
+$env:FUSION_PYTHON3_HOME = $pyBase
 
 & $venvPy (Join-Path $root "server.py")

--- a/run_server.ps1
+++ b/run_server.ps1
@@ -1,0 +1,44 @@
+<#
+    Launches the DaVinci Resolve MCP server with a clean, isolated environment.
+
+    Why a launcher: Resolve's fusionscript library binds to whatever `python3.dll`
+    it finds first. Other Pythons on PATH (Anaconda 3.12, python.org 3.13, ...)
+    will be loaded into this 3.10 interpreter and crash it. We therefore build a
+    minimal PATH that exposes ONLY this project's Python 3.10 plus the Windows
+    system directories. `resolve_env.py` additionally preloads the correct
+    python3.dll from inside the process as a second line of defense.
+
+    NOTE: Connecting to Resolve requires DaVinci Resolve *Studio*. The free edition
+    does not expose external scripting and the server will report that it could not
+    connect (it will not crash -- resolve_env probes safely first).
+#>
+
+$ErrorActionPreference = "Stop"
+$root = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+$venvPy = Join-Path $root ".venv310\Scripts\python.exe"
+if (-not (Test-Path $venvPy)) {
+    throw "Virtual environment not found at $venvPy. See README for setup."
+}
+
+# Resolve the base Python 3.10 install (the venv's 'home') from pyvenv.cfg.
+$pyBase = (Get-Content (Join-Path $root ".venv310\pyvenv.cfg") |
+    Where-Object { $_ -match '^\s*home\s*=' } |
+    ForEach-Object { ($_ -split '=', 2)[1].Trim() } |
+    Select-Object -First 1)
+
+# Minimal PATH: only our 3.10 + Windows system dirs. Deliberately excludes any
+# other Python / Anaconda dirs that would hijack the fusionscript DLL binding.
+$env:PATH = @(
+    (Join-Path $root ".venv310\Scripts"),
+    $pyBase,
+    (Join-Path $env:SystemRoot "System32"),
+    $env:SystemRoot
+) -join ';'
+
+$scripting = Join-Path $env:PROGRAMDATA "Blackmagic Design\DaVinci Resolve\Support\Developer\Scripting"
+$env:RESOLVE_SCRIPT_API = $scripting
+$env:RESOLVE_SCRIPT_LIB = Join-Path $env:PROGRAMFILES "Blackmagic Design\DaVinci Resolve\fusionscript.dll"
+$env:PYTHONPATH = Join-Path $scripting "Modules"
+
+& $venvPy (Join-Path $root "server.py")

--- a/server.py
+++ b/server.py
@@ -9,6 +9,10 @@ import logging
 import sys
 from typing import List, Dict, Any, Optional
 
+# Prepare the Resolve scripting environment (DLL preload + RESOLVE_SCRIPT_* paths)
+# BEFORE importing resolve_api, which loads Resolve's native scripting library.
+import resolve_env  # noqa: F401  (import for its bootstrap side effects)
+
 # Configure logging with timestamp, name, level, and message format
 logging.basicConfig(
     level=logging.INFO,

--- a/tests/test_resolve_env.py
+++ b/tests/test_resolve_env.py
@@ -1,0 +1,41 @@
+import os
+import pathlib
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+import resolve_env
+from resolve_api import ResolveAPI
+
+
+class ResolveEnvironmentTests(unittest.TestCase):
+    def setUp(self):
+        resolve_env._safe_to_import = None
+
+    def tearDown(self):
+        resolve_env._safe_to_import = None
+
+    def test_probe_receives_selected_module_path(self):
+        with tempfile.TemporaryDirectory() as module_path:
+            pathlib.Path(module_path, "DaVinciResolveScript.py").write_text(
+                "def scriptapp(name):\n"
+                "    return object()\n",
+                encoding="utf-8",
+            )
+            with mock.patch.dict(os.environ, {"PYTHONPATH": ""}):
+                self.assertTrue(resolve_env.scripting_safe_to_import(module_path))
+
+    def test_custom_module_path_is_added_to_sys_path(self):
+        with tempfile.TemporaryDirectory() as module_path:
+            with mock.patch.dict(
+                os.environ, {"RESOLVE_SCRIPT_PATH": module_path}, clear=False
+            ):
+                with mock.patch.object(sys, "path", list(sys.path)):
+                    api = ResolveAPI.__new__(ResolveAPI)
+                    self.assertEqual(api._find_scripting_module(), module_path)
+                    self.assertIn(module_path, sys.path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Makes the MCP server actually work on Windows by fixing the crash that occurred when importing DaVinci Resolve's scripting module, and by making the server degrade gracefully when a live connection isn't available.

Running the server previously died with an access violation (`0xC0000005`) on `import DaVinciResolveScript`, or (with `uv`) failed outright.

## Root cause

`fusionscript.dll` loads a Python 3 runtime when the scripting module is imported. It selects which interpreter from the `FUSION_PYTHON3_HOME` environment variable and, **when that is unset, from the Windows registry** (`HKCU`/`HKLM\SOFTWARE\Python\PythonCore`). On a machine with multiple Pythons registered (e.g. Anaconda 3.12), that fallback loads a *foreign* `python3xx.dll` into the running 3.10 interpreter and hard-crashes the process.

Crucially, **`PATH` isolation and preloading the correct `python3.dll` do not prevent this** — the registry fallback bypasses both. The reliable fix is to set `FUSION_PYTHON3_HOME`.

## Changes

- **`resolve_env.py` (new)** — bootstrap that sets `FUSION_PYTHON3_HOME` to the running interpreter, preloads the matching `python3.dll`, sets the `RESOLVE_SCRIPT_*` variables, and probes the scripting import in a subprocess so a native crash can't take down the server.
- **`run_server.ps1` (new)** — launcher that pins `FUSION_PYTHON3_HOME`, builds a minimal isolated `PATH`, and sets the scripting env vars.
- **`resolve_api.py`** — `_find_scripting_module()` now returns the Modules path even when it's already on `sys.path` (the launcher puts it there via `PYTHONPATH`), fixing a bogus "No valid Resolve scripting module path found" error; and it logs an honest message when `scriptapp()` returns `None` instead of claiming success.
- **`server.py`** — imports `resolve_env` first so the environment is prepared before the native library loads.
- **`README.md`** — documents Studio/Python-version requirements, the setup, and the real (registry) crash mechanism.

## Requirements / notes

- Requires **python.org Python 3.10/3.11** (not 3.12+, which removed `imp`; not `uv`'s standalone builds, which crash on `fusionscript.dll`).
- A **live connection requires DaVinci Resolve Studio** with *Preferences → System → General → "External scripting using" = Local*. On the free edition the server now starts and reports it's disconnected instead of crashing.
